### PR TITLE
[FIX] /api/links 경로 GET만 허용

### DIFF
--- a/baguni-api/src/main/java/baguni/security/config/SecurityConfig.java
+++ b/baguni-api/src/main/java/baguni/security/config/SecurityConfig.java
@@ -75,7 +75,7 @@ public class SecurityConfig {
 					.requestMatchers(HttpMethod.GET, "/api/shared/{uuid}").permitAll()
 					.requestMatchers(HttpMethod.POST, "/api/events/shared/**").permitAll() // 이벤트는 shared의 경우 검증 X
 					.requestMatchers("/api/login/**").permitAll()
-					.requestMatchers("/api/links").permitAll()
+					.requestMatchers(HttpMethod.GET, "/api/links").permitAll()
 					.anyRequest().authenticated()
 			)
 			.exceptionHandling((configurer ->
@@ -138,7 +138,7 @@ public class SecurityConfig {
 					.requestMatchers("/api-docs/**").permitAll()
 					.requestMatchers("/swagger-ui/**").permitAll()
 					.requestMatchers("/api/login/**").permitAll()
-					.requestMatchers("/api/links").permitAll()
+					.requestMatchers(HttpMethod.GET, "/api/links").permitAll()
 					.anyRequest().authenticated()
 			)
 			.exceptionHandling((configurer ->


### PR DESCRIPTION
## What is this PR? 🔍

- 기능 : 악성 사용자가 DB 이미지를 수정할 수 없도록 권한을 `GET`만 열어주도록 변경
    - `PATCH /api/links` 이미지 경로 수정 때문. 
- issue : #2  