### PR TITLE
[HOTFIX] Link 엔티티 생성/수정 시간 Auditing 제거

### DIFF
--- a/baguni-api/src/main/java/baguni/api/application/development/DevelopmentController.java
+++ b/baguni-api/src/main/java/baguni/api/application/development/DevelopmentController.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -32,11 +31,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 개발 전용 API를 제공하는 Controller입니다.
  * 운영에는 반영되지 않습니다.
  */
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @Profile({"local", "dev", "staging"})
@@ -112,11 +113,17 @@ public class DevelopmentController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "204", description = "시작 성공")
 	})
-	@Transactional
 	public ResponseEntity<Void> runLinkAnalyzeBatch() {
 		for (var link : linkRepository.getAllFeedLinks()) {
-			link.changeUpdatedAt(LocalDateTime.now().minusDays(100));
-			eventMessenger.send(new LinkReadEvent(link.getUrl()));
+			try {
+				// --------------------------------------------
+				link.changeUpdatedAt(LocalDateTime.now().minusDays(100));
+				linkRepository.save(link);
+				// --------------------------------------------
+				eventMessenger.send(new LinkReadEvent(link.getUrl()));
+			} catch (Exception e) {
+				log.error("링크 분석 시작 실패, url=", link.getUrl(), e);
+			}
 		}
 		return ResponseEntity.noContent().build();
 	}
@@ -130,12 +137,14 @@ public class DevelopmentController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "204", description = "시작 성공")
 	})
-	@Transactional
 	public ResponseEntity<Void> runLinkAnalyze(@Valid @RequestBody String feedUrl) {
+		// ----------------------------------
 		var link = linkRepository
 			.findByUrl(feedUrl)
+			.map(li -> li.changeUpdatedAt(LocalDateTime.now().minusDays(100)))
+			.map(linkRepository::save)
 			.orElseThrow(() -> new ServiceException(LinkErrorCode.LINK_NOT_FOUND));
-		link.changeUpdatedAt(LocalDateTime.now().minusDays(100));
+		// ----------------------------------
 		eventMessenger.send(new LinkReadEvent(link.getUrl()));
 		return ResponseEntity.noContent().build();
 	}

--- a/baguni-infra/src/main/java/baguni/infra/model/link/Link.java
+++ b/baguni-infra/src/main/java/baguni/infra/model/link/Link.java
@@ -9,7 +9,6 @@ import org.hibernate.annotations.ColumnDefault;
 
 import baguni.common.exception.base.ServiceException;
 import baguni.common.exception.error_code.LinkErrorCode;
-import baguni.infra.model.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -25,7 +24,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Link extends BaseEntity {
+public class Link {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -57,6 +56,12 @@ public class Link extends BaseEntity {
 
 	@Column(name = "summary", columnDefinition = "TEXT")
 	private String summary;
+
+	@Column(name = "created_at", updatable = false, nullable = false)
+	protected LocalDateTime createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	protected LocalDateTime updatedAt;
 
 	// Static Factory Method -------------
 

--- a/baguni-infra/src/main/java/baguni/infra/model/link/Link.java
+++ b/baguni-infra/src/main/java/baguni/infra/model/link/Link.java
@@ -116,8 +116,9 @@ public class Link extends BaseEntity {
 		return this.isRss;
 	}
 
-	public void changeUpdatedAt(LocalDateTime updatedAt) {
+	public Link changeUpdatedAt(LocalDateTime updatedAt) {
 		this.updatedAt = updatedAt;
+		return this;
 	}
 
 	// Private Builder -------------

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
       - --skip-character-set-client-handshake # 클라이언트 character set 값을 보낼 때 서버에서 이를 무시하는 명령어, docker linux에서 locale 설정하지 않아 default 값인 latin1로 설정
       - --lower_case_table_names=1
     networks:
-      - baguni-dev-network
+      - baguni-local-network
 
   # **********************************
   #   BAGUNI MESSAGE QUEUE


### PR DESCRIPTION
## What is this PR? 🔍

- 기능 : Link 엔티티 생성/수정 시간 Auditing 제거 = `BaseEntity 상속 제거`
    - :warning: JPA Auditing `@LastModifiedAt` 으로 인해 90일 이전 날짜 갱신이 안됩니다. (`null이 아닌 값을 넣어도 강제로 설정됨`)
    - 링크 테이블 DDL이 이미 자동 갱신되도록 잘 되어 있습니다. 
      따라서 null이 아닌 값에 대해 강제 갱신이 되도록 변경했습니다.
- issue : #34 