### PR TITLE
[REFCATOR] description 수정, content 공백 시 처리

### DIFF
--- a/baguni-batch/src/main/java/baguni/batch/domain/crawler/LinkCrawler.java
+++ b/baguni-batch/src/main/java/baguni/batch/domain/crawler/LinkCrawler.java
@@ -37,18 +37,24 @@ public class LinkCrawler {
 								   .orElse(crawlResult.getTag(Metadata.OG_TITLE)
 													  .orElse(""));
 
-			var description = crawlResult.getTag(Metadata.DESCRIPTION)
-										 .orElse(crawlResult.getTag(Metadata.OG_DESCRIPTION)
-															.orElse(""));
+			// 토스 글 중에 description에는 공백이 들어 있으므로, 더 긴 description 사용
+			// 참고 : https://toss.tech/article/32197
+			var desc = crawlResult.getTag(Metadata.DESCRIPTION).orElse("");
+			var ogDesc = crawlResult.getTag(Metadata.OG_DESCRIPTION).orElse("");
+			var description = (desc.length() >= ogDesc.length()) ? desc : ogDesc;
 
 			var imageUrl = correctImageUrl(url, crawlResult.getTag(Metadata.OG_IMAGE)
 														   .orElse(crawlResult.getTag(Metadata.IMAGE)
 																			  .orElse(crawlResult.getTag(Metadata.ICON)
 																								 .orElse(""))));
-			var content = crawlResult.getTag(Metadata.CONTENT)
-									 .orElse("");
 
-			if (title.isBlank() || imageUrl.isBlank() || content.isBlank()) {
+			// 토스 글 중에 p 태그가 없는 경우가 있어 content에 공백이 설정됨. -> description에 유효한 데이터가 있으므로 공백인 경우 사용
+			// 참고 : https://toss.tech/article/32197
+			var content = crawlResult.getTag(Metadata.CONTENT)
+									 .filter(c -> !c.isBlank())
+									 .orElse(description);
+
+			if (title.isBlank() || imageUrl.isBlank()) {
 				throw new ServiceException(LinkErrorCode.LINK_CRAWLING_FAILURE, "필수 필드 획득 실패, url : " + url);
 			}
 


### PR DESCRIPTION
- Close #24 

## What is this PR? 🔍

- 기능 : description 수정, content 공백 시 처리
- issue : #24

## Changes 📝
- description, og:description 중 길이 더 큰 것 사용
- p 태그가 없어서 content가 공백인 경우, description 사용

## ScreenShot 📷
https://toss.tech/article/32197
```
<meta name="description" content="">
<meta property="og:description" content="아무도 해본 적 없는 도메인, 누구도 정확히 모르는 복잡한 업무를 다룰 때 무엇에 집중해야 할까?
직접 법령 해석하며 끝까지 정책을 파고, 가장 최적화된 워크플로를 만든 이야기.">
```
<img width="771" alt="image" src="https://github.com/user-attachments/assets/936fefb3-c618-410b-9284-3ab314970715" />

## 기타
- 아예 없는 것보다 우선 채우는 것이 필요하다고 판단하였음.