### PR TITLE
[HOTFIX] LLM 글 분석 요청을 단일 Worker가 전담하도록 변경

### DIFF
--- a/baguni-batch/src/main/java/baguni/batch/domain/ai/ollama/OllamaAgent.java
+++ b/baguni-batch/src/main/java/baguni/batch/domain/ai/ollama/OllamaAgent.java
@@ -37,7 +37,7 @@ public class OllamaAgent extends AiAgent {
 			var resultJsonString = response.message().content();
 			var result = new ObjectMapper().readValue(resultJsonString, OllamaSummarizeResult.class);
 			return result.summary();
-		});
+		}, text);
 	}
 
 	@Override
@@ -49,7 +49,7 @@ public class OllamaAgent extends AiAgent {
 				.readValue(response.message().content(), OllamaCategorizeResult.class)
 				.category();
 			return cleanWords(category);
-		});
+		}, text);
 	}
 
 	@Override
@@ -61,7 +61,7 @@ public class OllamaAgent extends AiAgent {
 				.readValue(response.message().content(), OllamaGetKeywordsResult.class)
 				.keywords();
 			return keywords.stream().map(this::cleanWords).toList();
-		});
+		}, text);
 	}
 
 	// 강조 표시 특수 문자 등의 프롬프트 꾸미기 문자 제거
@@ -70,16 +70,17 @@ public class OllamaAgent extends AiAgent {
 		return word.replaceAll("\\*", "");
 	}
 
-	private <T> T tryCatchWrapper(String action, ThrowingSupplier<T> supplier) {
+	private <T> T tryCatchWrapper(String action, ThrowingSupplier<T> supplier, String text) {
 		long start = System.currentTimeMillis();
 		try {
+			log.info("{} 작업 시작, 데이터:{}", action, text);
 			return supplier.get();
 		} catch (Exception e) {
-			log.error("{} 에러 발생: {}", action, e.getMessage(), e);
+			log.error("{} 에러 발생:{} 데이터:{}", action, e.getMessage(), text, e);
 			throw new RuntimeException(e);
 		} finally {
 			long end = System.currentTimeMillis();
-			log.info("{} 소요 시간: {}ms", action, end - start);
+			log.info("{} 소요 시간:{}ms", action, end - start);
 		}
 	}
 }

--- a/baguni-batch/src/main/java/baguni/batch/domain/analyzer/ArticleAnalyzer.java
+++ b/baguni-batch/src/main/java/baguni/batch/domain/analyzer/ArticleAnalyzer.java
@@ -3,13 +3,11 @@ package baguni.batch.domain.analyzer;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import baguni.batch.domain.ai.AiAgent;
 import baguni.batch.lib.SplitText;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -22,10 +20,11 @@ public class ArticleAnalyzer {
 		this.aiAgent = aiAgent;
 	}
 
-	// TODO: change param to Article (title, content, author...)
-	public AnalyzeResult analyze(String content) {
+	public AnalyzeResult analyze(String text) {
+		long start = System.currentTimeMillis();
+		log.info("Analyzer 분석 시작. 데이터={}", text);
 
-		var summary = new SplitText(content)
+		var summary = new SplitText(text)
 			.byCharacterCount(1000).stream()
 			.map(subtext -> subtext.replaceAll("\n", ""))
 			.map(subText -> aiAgent.summarize(subText))
@@ -34,6 +33,9 @@ public class ArticleAnalyzer {
 		var category = aiAgent.categorize(summary);
 
 		var keywords = aiAgent.getKeywords(summary);
+
+		long end = System.currentTimeMillis();
+		log.info("Analyzer 분석 종료. 총 소요 시간:{}ms", end - start);
 
 		return AnalyzeResult
 			.builder()

--- a/baguni-batch/src/main/java/baguni/batch/domain/link/LinkService.java
+++ b/baguni-batch/src/main/java/baguni/batch/domain/link/LinkService.java
@@ -50,7 +50,7 @@ public class LinkService {
 				crawled.title(),
 				crawled.description(), // 삭제 예정
 				linkValidator.isAccessible(crawled.imageUrl()) ? crawled.imageUrl() : basicImageUrl,
-				crawled.content()
+				null // crawled.content() // 이제 저장 필요 없음
 			)
 		);
 

--- a/baguni-batch/src/main/java/baguni/batch/domain/link/LinkService.java
+++ b/baguni-batch/src/main/java/baguni/batch/domain/link/LinkService.java
@@ -3,6 +3,8 @@ package baguni.batch.domain.link;
 import java.util.ArrayList;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -25,6 +27,10 @@ public class LinkService {
 	private final LinkValidator linkValidator;
 	private final LinkDataHandler linkDataHandler;
 	private final ArticleAnalyzer articleAnalyzer;
+
+	private static final Executor executor = Executors.newSingleThreadExecutor(
+		runnable -> new Thread(runnable, "Analyzer-Single-Thread")
+	);
 
 	@Value("${basic.image-url}")
 	private String basicImageUrl;
@@ -54,19 +60,14 @@ public class LinkService {
 			)
 		);
 
-		/* (대체 안) 비동기로 분석 시작 예시.
-		 * By default, this runs with fork/join pool.
-		 * https://medium.com/@reetesh043/a-deep-dive-into-javas-forkjoinpool-mechanics-556f82d160fb
-		 */
+		/* 비동기 분석 시작 */
 		CompletableFuture
-			.supplyAsync(() -> articleAnalyzer.analyze(crawled.content()))
+			.supplyAsync(() -> articleAnalyzer.analyze(crawled.content()), executor)
 			.thenAccept((analyzeResult) -> { /* 분석 결과를 저장 */
-				// 1. 요약 업데이트 (테스트용)
-				linkDataHandler.updateLink(new LinkCommand.UpdateSummary(link.url(), analyzeResult.summary()));
-				// 2. 카테고리 업데이트 (테스트용)
 				var arr = new ArrayList<String>();
 				arr.add(analyzeResult.category());
 				arr.addAll(analyzeResult.keywords());
+				linkDataHandler.updateLink(new LinkCommand.UpdateSummary(link.url(), analyzeResult.summary()));
 				linkDataHandler.updateLink(new LinkCommand.UpdateCategories(link.url(), arr));
 			}).whenComplete((__, error) -> {
 				if (Objects.nonNull(error)) {


### PR DESCRIPTION
- `병렬 요청으로 인한 LLM 서버 부하` vs `요약 1000자의 문제`
    - 문제 원인을 파악하기 위한 실험코드입니다.
    - 단일 워커가 글 분석 요청을 처리하도록 수정하고 실패율을 측정합니다.