### PR TITLE
[FIX] 스테이징 서버에서 회원 가입 시 응답 값에 userId 추가

### DIFF
--- a/baguni-api/src/main/java/baguni/api/application/development/DevelopmentController.java
+++ b/baguni-api/src/main/java/baguni/api/application/development/DevelopmentController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import baguni.api.application.user.controller.dto.DevelopUserApiResponse;
 import baguni.api.application.user.controller.dto.UserApiMapper;
 import baguni.api.application.user.controller.dto.UserInfoApiResponse;
 import baguni.api.service.user.service.UserService;
@@ -50,11 +51,11 @@ public class DevelopmentController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "204", description = "테스트 계정 생성 성공")
 	})
-	public ResponseEntity<UserInfoApiResponse> createTestUserIdPassword(
+	public ResponseEntity<DevelopUserApiResponse> createTestUserIdPassword(
 		@Valid @RequestBody NamePassword namePassword
 	) {
 		var userInfo = userService.createTestUser(namePassword);
-		var response = userApiMapper.toApiResponse(userInfo);
+		var response = userApiMapper.toDevelopUserApiResponse(userInfo);
 		return ResponseEntity.ok(response);
 	}
 

--- a/baguni-api/src/main/java/baguni/api/application/user/controller/dto/DevelopUserApiResponse.java
+++ b/baguni-api/src/main/java/baguni/api/application/user/controller/dto/DevelopUserApiResponse.java
@@ -1,0 +1,24 @@
+package baguni.api.application.user.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+
+public record DevelopUserApiResponse(
+
+	@NotEmpty
+	@Schema(description = "사용자 id(pk)")
+	Long id,
+
+	@NotEmpty
+	@Schema(description = "사용자 식별 토큰")
+	String idToken,
+
+	@NotEmpty
+	@Schema(description = "사용자 이메일")
+	String email,
+
+	// Nullable
+	@Schema(description = "사용자 이름")
+	String name
+) {
+}

--- a/baguni-api/src/main/java/baguni/api/application/user/controller/dto/UserApiMapper.java
+++ b/baguni-api/src/main/java/baguni/api/application/user/controller/dto/UserApiMapper.java
@@ -16,4 +16,7 @@ public interface UserApiMapper {
 
 	@Mapping(expression = "java(userInfo.idToken().value())", target = "idToken")
 	UserInfoApiResponse toApiResponse(UserInfo userInfo);
+
+	@Mapping(expression = "java(userInfo.idToken().value())", target = "idToken")
+	DevelopUserApiResponse toDevelopUserApiResponse(UserInfo userInfo);
 }


### PR DESCRIPTION
## What is this PR? 🔍

- 기능 : 스테이징 서버에서 회원 가입 시 응답 값에 userId 추가

## Changes 📝
- 개발 서버 -> 스테이징으로 반영 시 llm 관련된 부분까지 머지될 수 있기 때문에 따로 브랜치 파서 적용
- 기존에 회원 가입 시 응답 값에 userId가 제공되지 않았음.
- playwright 테스트 시에 회원 가입 버튼 클릭 후 회원 탈퇴 API 호출하기 위해 userId가 필수적